### PR TITLE
Ignore local cache artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Byte-compiled / optimized / DLL files
+.DS_Store
 __pycache__/
 *.py[cod]
 *$py.class
@@ -128,3 +129,9 @@ dmypy.json
 # Pyre type checker
 .pyre/
 /.idea/
+git-status.sh
+
+.agent-sessions/
+.claude/
+.codex/
+review/


### PR DESCRIPTION
## Summary
- ignore macOS metadata and Python cache artifacts
- ignore agent runtime/session scratch directories

## Verification
- inspected branch diff: .gitignore only
- kept staged dataset additions out of this PR